### PR TITLE
Fix: Avoid excessive log spamming during tests

### DIFF
--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,5 @@
+# Avoid excessive log spam from Pi4J
+org.slf4j.simpleLogger.log.com.pi4j.Pi4J=warn
+org.slf4j.simpleLogger.log.com.pi4j.platform.impl.DefaultRuntimePlatforms=warn
+org.slf4j.simpleLogger.log.com.pi4j.plugin.mock.provider.i2c.MockI2C=warn
+org.slf4j.simpleLogger.log.com.pi4j.plugin.mock.provider.spi.MockSpi=warn


### PR DESCRIPTION
This PR raises the minimum logging level for the following classes to `warn`:

- `com.pi4j.Pi4J`
- `com.pi4j.platform.impl.DefaultRuntimePlatforms`
- `com.pi4j.plugin.mock.provider.i2c.MockI2C`
- `com.pi4j.plugin.mock.provider.spi.MockSpi`

This will suppress excessive log spamming which sometimes even caused GitHub Actions to fail due to too much console output.