### PR TITLE
Feature: Step Motor Component

### DIFF
--- a/src/main/java/com/pi4j/crowpi/Launcher.java
+++ b/src/main/java/com/pi4j/crowpi/Launcher.java
@@ -36,6 +36,7 @@ public final class Launcher implements Runnable {
         new RelayApp(),
         new SevenSegmentApp(),
         new SoundSensorApp(),
+        new StepMotorApp(),
         new TiltSensorApp(),
         new TouchSensorApp(),
         new UltrasonicDistanceSensorApp(),

--- a/src/main/java/com/pi4j/crowpi/applications/StepMotorApp.java
+++ b/src/main/java/com/pi4j/crowpi/applications/StepMotorApp.java
@@ -4,12 +4,44 @@ import com.pi4j.context.Context;
 import com.pi4j.crowpi.Application;
 import com.pi4j.crowpi.components.StepMotorComponent;
 
+/**
+ * This example shows how the step motor on the CrowPi can be used. It allows for precise rotation in either direction and requires the DIP
+ * switches 3, 4, 5 and 6 on the right DIP switch to be set. Turning by either a given count or degrees is being demonstrated below.
+ */
 public class StepMotorApp implements Application {
     @Override
     public void execute(Context pi4j) {
+        // Initialize step motor with default configuration for CrowPi
         final var stepMotor = new StepMotorComponent(pi4j);
 
-        stepMotor.turnDegrees(360);
-        stepMotor.turnDegrees(-360);
+        // 'Warn' the user about the upcoming action
+        System.out.println("Watch your step motor closely, it will start moving in 5 seconds...");
+        sleep(5000);
+
+        // Turn the motor 50 times forward and backward, resulting in the same position
+        System.out.println("Moving 50 steps forward...");
+        stepMotor.turnForward(50);
+        sleep(1000);
+
+        System.out.println("...and moving 50 steps backward...");
+        stepMotor.turnBackward(50);
+
+        System.out.println("...and we are back at our previous position!");
+        sleep(1000);
+
+        // Simulate a sweeping motion (forward -> backward + backward -> forward)
+        for (int i = 5; i > 0; i--) {
+            System.out.println("Sweep sweep sweep... just " + i + " more times");
+
+            // Start by rotating 90 degrees forward...
+            stepMotor.turnDegrees(90);
+
+            // ...then rotating 180 degrees backwards to the other side...
+            // note: a negative amount of degrees means going backward
+            stepMotor.turnDegrees(-180);
+
+            // ...then back to the center by going 90 degrees forward again
+            stepMotor.turnDegrees(90);
+        }
     }
 }

--- a/src/main/java/com/pi4j/crowpi/applications/StepMotorApp.java
+++ b/src/main/java/com/pi4j/crowpi/applications/StepMotorApp.java
@@ -1,0 +1,15 @@
+package com.pi4j.crowpi.applications;
+
+import com.pi4j.context.Context;
+import com.pi4j.crowpi.Application;
+import com.pi4j.crowpi.components.StepMotorComponent;
+
+public class StepMotorApp implements Application {
+    @Override
+    public void execute(Context pi4j) {
+        final var stepMotor = new StepMotorComponent(pi4j);
+
+        stepMotor.turnDegrees(360);
+        stepMotor.turnDegrees(-360);
+    }
+}

--- a/src/main/java/com/pi4j/crowpi/components/StepMotorComponent.java
+++ b/src/main/java/com/pi4j/crowpi/components/StepMotorComponent.java
@@ -1,0 +1,184 @@
+package com.pi4j.crowpi.components;
+
+import com.pi4j.context.Context;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalOutputConfig;
+import com.pi4j.io.gpio.digital.DigitalState;
+
+import java.util.*;
+
+/**
+ * Implementation of the CrowPi Step Motor using GPIO with Pi4J
+ */
+public class StepMotorComponent extends Component {
+    /**
+     * Default GPIO BCM addresses used as part of the various steps
+     */
+    private final static int[] DEFAULT_PINS = {5, 6, 13, 19};
+    /**
+     * Default set of steps which will be executed once in order when turning one step
+     *
+     * @see #StepMotorComponent(Context, int[], int[][], long)
+     */
+    private final static int[][] DEFAULT_STEPS = {
+        {3, 0},
+        {0},
+        {0, 1},
+        {1},
+        {1, 2},
+        {2},
+        {3, 2},
+        {3},
+    };
+    /**
+     * Default duration in milliseconds when pulsing one step, increasing this value makes the step motor turn slower.
+     */
+    private static final long DEFAULT_PULSE_MILLISECONDS = 1;
+
+    /**
+     * Desired pulse duration in milliseconds when executing a single step
+     */
+    private final long pulseMilliseconds;
+    /**
+     * Pre-generated list of forward steps, containing a set of all digital outputs which need to be pulsed for each step
+     */
+    private final List<Set<DigitalOutput>> stepsForward;
+    /**
+     * Pre-generated list of backward steps, always equal to {@link #stepsForward} in reversed order.
+     */
+    private final List<Set<DigitalOutput>> stepsBackward;
+
+    /**
+     * Creates a new step motor component with the default pins, steps and pulse duration.
+     *
+     * @param pi4j Pi4J context
+     */
+    public StepMotorComponent(Context pi4j) {
+        this(pi4j, DEFAULT_PINS, DEFAULT_STEPS, DEFAULT_PULSE_MILLISECONDS);
+    }
+
+    /**
+     * Creates a new step motor component with custom pins, steps and pulse duration.
+     * <p>
+     * The first dimension of {@code steps} represents the various steps which are to be executed in order.
+     * The second dimension of {@code steps} represents which output(s) should be pulsed for the current step.
+     * Please note that the second dimension does not store the pin addresses but the index within {@code addresses}.
+     *
+     * @param pi4j              Pi4J context
+     * @param addresses         Array of BCM pin addresses to be driven during steps
+     * @param steps             Two-dimensional array containing steps with their associated pins
+     * @param pulseMilliseconds Duration in milliseconds for pulses
+     */
+    public StepMotorComponent(Context pi4j, int[] addresses, int[][] steps, long pulseMilliseconds) {
+        this.pulseMilliseconds = pulseMilliseconds;
+
+        // Initialize digital outputs
+        final var outputs = new DigitalOutput[addresses.length];
+        for (int i = 0; i < addresses.length; i++) {
+            outputs[i] = pi4j.create(buildDigitalOutputConfig(pi4j, addresses[i]));
+        }
+
+        // Transform two-dimensional array with steps into List<Set<DigitalOutput>>
+        // The first dimension of the array indicates which step is being described
+        // The second dimension of the array indicates which outputs (referenced by their index) should be driven
+        this.stepsForward = new ArrayList<>();
+        for (final var step : steps) {
+            // Generate set of outputs driven as part of this step
+            final var stepOutputs = new HashSet<DigitalOutput>();
+            for (final var outputIndex : step) {
+                // Ensure output index is within bounds
+                if (outputIndex < 0 || outputIndex > outputs.length) {
+                    throw new IllegalArgumentException("Output index must be between 0 and " + outputs.length);
+                }
+
+                // Add specified output to set
+                stepOutputs.add(outputs[outputIndex]);
+            }
+
+            // Add collected step outputs to list of steps
+            this.stepsForward.add(stepOutputs);
+        }
+
+        // Generate list of reversed steps
+        this.stepsBackward = new ArrayList<>();
+        this.stepsBackward.addAll(this.stepsForward);
+        Collections.reverse(this.stepsBackward);
+    }
+
+    /**
+     * Turns the step motor by the given amount of degrees.
+     * If a negative value is specified, the motor will automatically turn backward.
+     *
+     * @param degrees Number of degrees to turn for- or backward
+     */
+    public void turnDegrees(int degrees) {
+        final int steps = degrees * 512 / 360;
+        if (steps >= 0) {
+            turnForward(steps);
+        } else {
+            turnBackward(steps * -1);
+        }
+    }
+
+    /**
+     * Turns the step motor forward for the given amount of steps.
+     *
+     * @param steps Steps to turn forward
+     */
+    public void turnForward(int steps) {
+        turn(steps, stepsForward);
+    }
+
+    /**
+     * Turns the step motor backward for the given amount of steps.
+     *
+     * @param steps Steps to turn backward
+     */
+    public void turnBackward(int steps) {
+        turn(steps, stepsBackward);
+    }
+
+    /**
+     * Turns the step motor for the given amount of steps using the provided step data.
+     *
+     * @param count Amount of steps to be turned
+     * @param steps List of steps with associated digital outputs to iterate through
+     */
+    private void turn(int count, List<Set<DigitalOutput>> steps) {
+        // Loop to reach desired count of steps
+        for (int i = 0; i < count; i++) {
+            // Iterate through all known steps
+            for (final var step : steps) {
+                // Turn all outputs for the current step to HIGH
+                for (final var output : step) {
+                    output.high();
+                }
+
+                // Sleep for the given duration in milliseconds
+                sleep(pulseMilliseconds);
+
+                // Turn all outputs for the current step to LOW
+                for (final var output : step) {
+                    output.low();
+                }
+            }
+        }
+    }
+
+    /**
+     * Builds a new digital output configuration for the GPIO step motor pin
+     *
+     * @param pi4j    Pi4J context
+     * @param address BCM address
+     * @return Digital output configuration
+     */
+    protected DigitalOutputConfig buildDigitalOutputConfig(Context pi4j, int address) {
+        return DigitalOutput.newConfigBuilder(pi4j)
+            .id("BCM" + address)
+            .name("Step Motor @ BCM" + address)
+            .address(address)
+            .initial(DigitalState.LOW)
+            .shutdown(DigitalState.LOW)
+            .build();
+    }
+}

--- a/src/main/java/com/pi4j/crowpi/components/StepMotorComponent.java
+++ b/src/main/java/com/pi4j/crowpi/components/StepMotorComponent.java
@@ -40,6 +40,10 @@ public class StepMotorComponent extends Component {
      */
     private final long pulseMilliseconds;
     /**
+     * Array of digital outputs used by this component, can be contained within {@link #stepsForward} or {@link #stepsBackward}
+     */
+    private final DigitalOutput[] digitalOutputs;
+    /**
      * Pre-generated list of forward steps, containing a set of all digital outputs which need to be pulsed for each step
      */
     private final List<Set<DigitalOutput>> stepsForward;
@@ -73,9 +77,9 @@ public class StepMotorComponent extends Component {
         this.pulseMilliseconds = pulseMilliseconds;
 
         // Initialize digital outputs
-        final var outputs = new DigitalOutput[addresses.length];
+        this.digitalOutputs = new DigitalOutput[addresses.length];
         for (int i = 0; i < addresses.length; i++) {
-            outputs[i] = pi4j.create(buildDigitalOutputConfig(pi4j, addresses[i]));
+            this.digitalOutputs[i] = pi4j.create(buildDigitalOutputConfig(pi4j, addresses[i]));
         }
 
         // Transform two-dimensional array with steps into List<Set<DigitalOutput>>
@@ -84,15 +88,15 @@ public class StepMotorComponent extends Component {
         this.stepsForward = new ArrayList<>();
         for (final var step : steps) {
             // Generate set of outputs driven as part of this step
-            final var stepOutputs = new HashSet<DigitalOutput>();
+            final var stepOutputs = new LinkedHashSet<DigitalOutput>();
             for (final var outputIndex : step) {
                 // Ensure output index is within bounds
-                if (outputIndex < 0 || outputIndex > outputs.length) {
-                    throw new IllegalArgumentException("Output index must be between 0 and " + outputs.length);
+                if (outputIndex < 0 || outputIndex > this.digitalOutputs.length) {
+                    throw new IllegalArgumentException("Output index must be between 0 and " + this.digitalOutputs.length);
                 }
 
                 // Add specified output to set
-                stepOutputs.add(outputs[outputIndex]);
+                stepOutputs.add(this.digitalOutputs[outputIndex]);
             }
 
             // Add collected step outputs to list of steps
@@ -163,6 +167,15 @@ public class StepMotorComponent extends Component {
                 }
             }
         }
+    }
+
+    /**
+     * Returns an array of all initialized digital outputs for this component
+     *
+     * @return Digital output instances
+     */
+    protected DigitalOutput[] getDigitalOutputs() {
+        return digitalOutputs;
     }
 
     /**

--- a/src/test/java/com/pi4j/crowpi/ComponentTest.java
+++ b/src/test/java/com/pi4j/crowpi/ComponentTest.java
@@ -22,6 +22,8 @@ import com.pi4j.plugin.mock.provider.spi.MockSpiProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
+import java.util.Arrays;
+
 public abstract class ComponentTest {
     protected Context pi4j;
 
@@ -45,7 +47,7 @@ public abstract class ComponentTest {
 
     @SuppressWarnings("RedundantThrows")
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDownBase() throws Exception {
         pi4j.shutdown();
     }
 
@@ -55,6 +57,10 @@ public abstract class ComponentTest {
 
     protected MockDigitalOutput toMock(DigitalOutput digitalOutput) {
         return toMock(MockDigitalOutput.class, digitalOutput);
+    }
+
+    protected MockDigitalOutput[] toMock(DigitalOutput[] digitalOutputs) {
+        return Arrays.stream(digitalOutputs).map(this::toMock).toArray(MockDigitalOutput[]::new);
     }
 
     protected MockI2C toMock(I2C i2c) {
@@ -68,4 +74,5 @@ public abstract class ComponentTest {
     private <T> T toMock(Class<T> type, Object instance) {
         return type.cast(instance);
     }
+
 }

--- a/src/test/java/com/pi4j/crowpi/DigitalOutputMonitor.java
+++ b/src/test/java/com/pi4j/crowpi/DigitalOutputMonitor.java
@@ -1,0 +1,81 @@
+package com.pi4j.crowpi;
+
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.io.gpio.digital.DigitalStateChangeEvent;
+import com.pi4j.io.gpio.digital.DigitalStateChangeListener;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public final class DigitalOutputMonitor implements DigitalStateChangeListener {
+    private final List<StateChange> stateChanges = Collections.synchronizedList(new ArrayList<>());
+
+    public DigitalOutputMonitor(DigitalOutput... digitalOutputs) {
+        this.attach(digitalOutputs);
+    }
+
+    public void attach(DigitalOutput... digitalOutputs) {
+        Arrays.asList(digitalOutputs).forEach(o -> o.addListener(this));
+    }
+
+    public void detach(DigitalOutput... digitalOutputs) {
+        Arrays.asList(digitalOutputs).forEach(o -> o.removeListener(this));
+    }
+
+    public List<StateChange> getStateChanges() {
+        return Collections.unmodifiableList(stateChanges);
+    }
+
+    public void assertStateChanges(StateChange... stateChanges) {
+        assertStateChanges(Arrays.asList(stateChanges));
+    }
+
+    public void assertStateChanges(List<StateChange> expectedStateChanges) {
+        assertEquals(expectedStateChanges, getStateChanges());
+    }
+
+    @Override
+    public void onDigitalStateChange(DigitalStateChangeEvent event) {
+        if (event.source() instanceof DigitalOutput) {
+            stateChanges.add(new StateChange((DigitalOutput) event.source(), event.state()));
+        }
+    }
+
+    public static final class StateChange {
+        private final DigitalOutput digitalOutput;
+        private final DigitalState state;
+
+        public StateChange(DigitalOutput digitalOutput, DigitalState state) {
+            this.digitalOutput = digitalOutput;
+            this.state = state;
+        }
+
+        public DigitalOutput getDigitalOutput() {
+            return digitalOutput;
+        }
+
+        public DigitalState getState() {
+            return state;
+        }
+
+        @Override
+        public String toString() {
+            return digitalOutput.id() + "=" + state.getName();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            StateChange that = (StateChange) o;
+            return Objects.equals(digitalOutput, that.digitalOutput) && state == that.state;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(digitalOutput, state);
+        }
+    }
+}

--- a/src/test/java/com/pi4j/crowpi/components/StepMotorComponentTest.java
+++ b/src/test/java/com/pi4j/crowpi/components/StepMotorComponentTest.java
@@ -1,0 +1,165 @@
+package com.pi4j.crowpi.components;
+
+import com.pi4j.crowpi.ComponentTest;
+import com.pi4j.crowpi.DigitalOutputMonitor;
+import com.pi4j.crowpi.DigitalOutputMonitor.StateChange;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.plugin.mock.provider.gpio.digital.MockDigitalOutput;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.pi4j.io.gpio.digital.DigitalState.HIGH;
+import static com.pi4j.io.gpio.digital.DigitalState.LOW;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StepMotorComponentTest extends ComponentTest {
+    protected StepMotorComponent stepMotor;
+    protected MockDigitalOutput[] digitalOutputs;
+    protected DigitalOutputMonitor digitalOutputMonitor;
+
+    @BeforeEach
+    void setUp() {
+        this.stepMotor = new StepMotorComponent(pi4j);
+        this.digitalOutputs = toMock(stepMotor.getDigitalOutputs());
+        this.digitalOutputMonitor = new DigitalOutputMonitor(digitalOutputs);
+    }
+
+    @Test
+    void testInvalidStepData() {
+        // when
+        final Executable t = () -> new StepMotorComponent(pi4j, new int[]{1, 2, 3}, new int[][]{{4}}, 1);
+
+        // then
+        assertThrows(IllegalArgumentException.class, t);
+    }
+
+    @Test
+    void testTurnPositiveDegrees() {
+        // when rotating by +5 degrees
+        stepMotor.turnDegrees(5);
+
+        // then expect 7 forward steps
+        digitalOutputMonitor.assertStateChanges(repeatStateChanges(7, getForwardSteps()));
+    }
+
+    @Test
+    void testTurnNegativeDegrees() {
+        // when rotating by -5 degrees
+        stepMotor.turnDegrees(-5);
+
+        // then expect 7 backward steps
+        digitalOutputMonitor.assertStateChanges(repeatStateChanges(7, getBackwardSteps()));
+    }
+
+    @Test
+    void testTurnForward() {
+        // when
+        stepMotor.turnForward(1);
+
+        // then
+        digitalOutputMonitor.assertStateChanges(getForwardSteps());
+    }
+
+    @Test
+    void testTurnBackward() {
+        // when
+        stepMotor.turnBackward(1);
+
+        // then
+        digitalOutputMonitor.assertStateChanges(getBackwardSteps());
+    }
+
+    private StateChange[] getForwardSteps() {
+        return new StateChange[]{
+            // Step #0
+            stateChange(3, HIGH), stateChange(0, HIGH),
+            stateChange(3, LOW), stateChange(0, LOW),
+
+            // Step #1
+            stateChange(0, HIGH),
+            stateChange(0, LOW),
+
+            // Step #2
+            stateChange(0, HIGH), stateChange(1, HIGH),
+            stateChange(0, LOW), stateChange(1, LOW),
+
+            // Step #3
+            stateChange(1, HIGH),
+            stateChange(1, LOW),
+
+            // Step #4
+            stateChange(1, HIGH), stateChange(2, HIGH),
+            stateChange(1, LOW), stateChange(2, LOW),
+
+            // Step #5
+            stateChange(2, HIGH),
+            stateChange(2, LOW),
+
+            // Step #6
+            stateChange(3, HIGH), stateChange(2, HIGH),
+            stateChange(3, LOW), stateChange(2, LOW),
+
+            // Step #7
+            stateChange(3, HIGH),
+            stateChange(3, LOW),
+        };
+    }
+
+    private StateChange[] getBackwardSteps() {
+        return new StateChange[]{
+            // Step #0
+            stateChange(3, HIGH),
+            stateChange(3, LOW),
+
+            // Step #1
+            stateChange(3, HIGH), stateChange(2, HIGH),
+            stateChange(3, LOW), stateChange(2, LOW),
+
+            // Step #2
+            stateChange(2, HIGH),
+            stateChange(2, LOW),
+
+            // Step #3
+            stateChange(1, HIGH), stateChange(2, HIGH),
+            stateChange(1, LOW), stateChange(2, LOW),
+
+            // Step #4
+            stateChange(1, HIGH),
+            stateChange(1, LOW),
+
+            // Step #5
+            stateChange(0, HIGH), stateChange(1, HIGH),
+            stateChange(0, LOW), stateChange(1, LOW),
+
+            // Step #6
+            stateChange(0, HIGH),
+            stateChange(0, LOW),
+
+            // Step #7
+            stateChange(3, HIGH), stateChange(0, HIGH),
+            stateChange(3, LOW), stateChange(0, LOW),
+        };
+    }
+
+    private StateChange stateChange(int digitalOutputIndex, DigitalState digitalState) {
+        return new StateChange(digitalOutputs[digitalOutputIndex], digitalState);
+    }
+
+    private List<StateChange> repeatStateChanges(int count, StateChange... stateChanges) {
+        // Convert state changes into list
+        final var singleList = Arrays.asList(stateChanges);
+
+        // Create new list with enough capacity to store the initial list times `count` and insert elements
+        final var resultList = new ArrayList<StateChange>(singleList.size() * count);
+        for (int i = 0; i < count; i++) {
+            resultList.addAll(singleList);
+        }
+
+        return resultList;
+    }
+}


### PR DESCRIPTION
This PR implements the step motor component (see ppmathis/fhnw-crowpi#22) of the Pi4J, which can be plugged into the dedicated `STEP MOTOR` port on the bottom right side of the CrowPi.

The API allows rotating in both directions specified in either turns or degrees and is flexible enough to support other step motors as well as both pins and steps can be given via the constructor.

A new test helper `DigitalOutputMonitor` has been added as we currently had no way to protocol/log the state changes of multiple digital outputs and compare them to a given state, which this test class allows doing.