### PR TITLE
Feature: IR Receiver Component

### DIFF
--- a/src/main/java/com/pi4j/crowpi/Launcher.java
+++ b/src/main/java/com/pi4j/crowpi/Launcher.java
@@ -28,6 +28,7 @@ public final class Launcher implements Runnable {
         new ButtonMatrixApp(),
         new BuzzerApp(),
         new ExampleApp(),
+        new IrReceiverApp(),
         new LcdDisplayApp(),
         new LedMatrixApp(),
         new LightSensorApp(),

--- a/src/main/java/com/pi4j/crowpi/applications/IrReceiverApp.java
+++ b/src/main/java/com/pi4j/crowpi/applications/IrReceiverApp.java
@@ -1,0 +1,43 @@
+package com.pi4j.crowpi.applications;
+
+import com.pi4j.context.Context;
+import com.pi4j.crowpi.Application;
+import com.pi4j.crowpi.components.IrReceiverComponent;
+
+/**
+ * This example demonstrates the infrared receiver component on the CrowPi. Please note that the receiver LED must first be plugged into the
+ * three small pinholes labelled as "IR" for this example to work. As Java does not allow for precise enough timings itself, this component
+ * does not use Pi4J to retrieve the pulses of the GPIO pin for the IR sensor and instead relies on mode2, an executable provided as part of
+ * LIRC for reading from an IR input.
+ * <p>
+ * A clean alternative would be using a separate microcontroller which handles the super precise timing-based communication itself and
+ * interacts with the Raspberry Pi using I²C, SPI or any other bus. This would offload the work and guarantee even more accurate results. As
+ * the CrowPi does not have such a dedicated microcontroller though, using `mode2` was the best available approach.
+ */
+public class IrReceiverApp implements Application {
+    @Override
+    public void execute(Context pi4j) {
+        // Initialize the IR receiver component
+        // We do not use Pi4J here at all, so there is no need to pass the context...
+        final var ir = new IrReceiverComponent();
+
+        // Register an event listener for key presses
+        System.out.println("Welcome to the IR demo! An event listener for key presses will now be registered...");
+        ir.onKeyPressed(key -> {
+            // Print the key which just has been pressed
+            System.out.println("Key on IR remote has been pressed: " + key);
+
+            // It is also possible to check if a specific key was pressed
+            if (key == IrReceiverComponent.Key.CH) {
+                System.out.println("You pressed the super special CH key! (it is actually not special, sorry to disappoint)");
+            }
+        });
+
+        // Give the user some time to press buttons
+        System.out.println("Done! You now have 30 seconds to try out pressing various keys on the IR remote...");
+        sleep(30000);
+
+        // Cleanup the event listener
+        ir.onKeyPressed(null);
+    }
+}

--- a/src/main/java/com/pi4j/crowpi/components/IrReceiverComponent.java
+++ b/src/main/java/com/pi4j/crowpi/components/IrReceiverComponent.java
@@ -1,0 +1,612 @@
+package com.pi4j.crowpi.components;
+
+import com.pi4j.crowpi.components.events.EventHandler;
+import com.pi4j.crowpi.components.helpers.ByteHelpers;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+/**
+ * Implementation of the CrowPi IR receiver /not/ using GPIO with Pi4J
+ * <p>
+ * Unfortunately the tight timing constraints of the infrared receiver which are in the area of microseconds can not be handled by the JVM.
+ * While Pi4J does not drop any event and still processes them reliably, the timing is too far off to be useful for any signal processing.
+ * As the bundled IR remote of the CrowPi can be used as a great input device, this class provides an alternative without Pi4J.
+ * <p>
+ * The binary `mode2` provided by the LIRC software package is being used to record the pulses of the IR transmitter / remote.
+ * This implementation will automatically run `mode2` pointed towards a `lirc` kernel device and parses its output to recognize IR signals.
+ * While receiving the pulses is done outside of Java, all the processing and handling is still being covered as part of this class.
+ */
+public class IrReceiverComponent extends Component {
+    /**
+     * Default binary path to the `mode2` binary of the LIRC software package
+     */
+    private final static String DEFAULT_MODE2_BINARY = "/usr/bin/mode2";
+    /**
+     * Default kernel device path for the IR receiver
+     */
+    private final static String DEFAULT_DEVICE_PATH = "/dev/lirc0";
+
+    /**
+     * Binary path to `mode2` used for polling
+     */
+    private final String mode2Binary;
+    /**
+     * Kernel device path for interacting with the IR receiver
+     */
+    private final String devicePath;
+
+    /**
+     * Current instance of poller manager or null if not running
+     */
+    private PollerManager pollerManager;
+    /**
+     * Current thread instance of the poller manager or null if not running
+     */
+    private Thread pollerManagerThread;
+
+    /**
+     * Handler for received IR key press
+     */
+    private final AtomicReference<EventHandler<Key>> onKeyPressedHandler;
+
+    /**
+     * Default poller process factory, should only be changed during tests for proper mocking.
+     */
+    protected PollerProcessFactory pollerProcessFactory = this::createNativePollerProcess;
+
+    /**
+     * Creates a new IR receiver using the default binary and kernel device path.
+     */
+    public IrReceiverComponent() {
+        this(DEFAULT_MODE2_BINARY, DEFAULT_DEVICE_PATH);
+    }
+
+    /**
+     * Creates a new IR receiver using a custom mode2 binary and kernel device path.
+     *
+     * @param mode2Binary Path to `mode2` binary provided by LIRC
+     * @param devicePath  Absolute path to kernel device, e.g. /dev/lirc0
+     */
+    public IrReceiverComponent(String mode2Binary, String devicePath) {
+        this.mode2Binary = mode2Binary;
+        this.devicePath = devicePath;
+        this.onKeyPressedHandler = new AtomicReference<>();
+    }
+
+    /**
+     * Sets or disables the handler for received IR key presses.
+     * This will automatically start or stop the poller as needed.
+     *
+     * @param handler Event handler to call or null to disable
+     */
+    public synchronized void onKeyPressed(EventHandler<Key> handler) {
+        if (handler != null) {
+            startPollerManager();
+            onKeyPressedHandler.set(handler);
+        } else {
+            onKeyPressedHandler.set(null);
+            stopPollerManager();
+        }
+    }
+
+    /**
+     * Returns the instance of the poller manager or null if currently not running.
+     *
+     * @return Poller manager instance or null
+     */
+    protected PollerManager getPollerManager() {
+        return pollerManager;
+    }
+
+    /**
+     * Returns the instance of the poller manager thread or null if currently not running.
+     *
+     * @return Poller manager thread or null
+     */
+    protected Thread getPollerManagerThread() {
+        return pollerManagerThread;
+    }
+
+    /**
+     * Starts the poller manager if not already running.
+     */
+    private void startPollerManager() {
+        if (this.pollerManagerThread == null) {
+            this.pollerManager = new PollerManager();
+            this.pollerManagerThread = new Thread(this.pollerManager);
+            this.pollerManagerThread.start();
+        }
+    }
+
+    /**
+     * Stops the poller manager if currently running.
+     */
+    private void stopPollerManager() {
+        if (this.pollerManagerThread != null) {
+            this.pollerManagerThread.interrupt();
+            try {
+                this.pollerManagerThread.join();
+            } catch (InterruptedException e) {
+                logger.warn("Could not stop IR signal poller manager", e);
+            } finally {
+                this.pollerManagerThread = null;
+                this.pollerManager = null;
+            }
+        }
+    }
+
+    /**
+     * Starts a new poller process using {@link ProcessBuilder} and returns a {@link NativePollerProcess} instance.
+     * This will use {@link #mode2Binary} and {@link #devicePath} for constructing the proper arguments.
+     * Using a separate method for this allows properly unit testing the poller thread itself.
+     *
+     * @return Process instance
+     */
+    private NativePollerProcess createNativePollerProcess() throws IOException {
+        final var processBuilder = new ProcessBuilder(
+            mode2Binary,
+            "--driver", "default",
+            "--device", devicePath
+        );
+        return new NativePollerProcess(processBuilder.start());
+    }
+
+    /**
+     * Functional interface for a poller process factory which creates new {@link PollerProcess} instances on demand.
+     */
+    @FunctionalInterface
+    protected interface PollerProcessFactory {
+        PollerProcess create() throws IOException;
+    }
+
+    /**
+     * Custom interface as an alternative to the Java native {@link Process} interface.
+     * This is required for proper unit testing of the poller as Java provides no sane way for mocking {@link Process} itself.
+     */
+    protected interface PollerProcess {
+        InputStream getInputStream();
+
+        boolean isAlive();
+
+        void destroy();
+    }
+
+    /**
+     * Implementation of {@link PollerProcess} which wraps around a regular Java {@link Process} instance.
+     */
+    private static final class NativePollerProcess implements PollerProcess {
+        private final Process process;
+
+        public NativePollerProcess(Process process) {
+            this.process = process;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return process.getInputStream();
+        }
+
+        @Override
+        public boolean isAlive() {
+            return process.isAlive();
+        }
+
+        @Override
+        public void destroy() {
+            process.destroy();
+        }
+    }
+
+    /**
+     * Poller manager class which implements {@link Runnable} and should be ran in a separate thread.
+     * This poller manager will automatically launch a poller process and thread and monitors them.
+     * In case either the poller process or thread dies, it will be automatically restarted.
+     * This thread continues to run until the interrupted flag gets set.
+     */
+    protected final class PollerManager implements Runnable {
+        private Poller poller;
+        private PollerProcess pollerProcess;
+        private Thread pollerThread;
+
+        @Override
+        public void run() {
+            // Attempt to start IR signal poller
+            try {
+                restartPoller();
+            } catch (IOException | InterruptedException e) {
+                logger.error("Could not start IR signal poller", e);
+                return;
+            }
+
+            // Monitor IR signal poller and auto-restart if needed
+            while (!Thread.interrupted()) {
+                if (!pollerProcess.isAlive() || !pollerThread.isAlive()) {
+                    logger.warn("Restarting IR signal poller after crash");
+                    try {
+                        restartPoller();
+                    } catch (IOException | InterruptedException e) {
+                        logger.error("Could not restart IR signal poller", e);
+                        return;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Returns the current poller process managed by this poller manager or null if not running.
+         *
+         * @return Instance of poller process
+         */
+        protected PollerProcess getPollerProcess() {
+            return pollerProcess;
+        }
+
+        /**
+         * (Re-)start the poller process and thread.
+         * If the poller is not already running, it will be just launched regularly.
+         * If the poller is already running, it will be stopped and a new poller gets launched.
+         *
+         * @throws InterruptedException Stopping of previous poller instance was interrupted
+         * @throws IOException          Could not launch poller process
+         */
+        private void restartPoller() throws InterruptedException, IOException {
+            // Stop any previous poller, we can not run twice
+            stopPoller();
+
+            // Start poller process and thread
+            this.pollerProcess = pollerProcessFactory.create();
+            this.poller = new Poller(pollerProcess.getInputStream());
+            this.pollerThread = new Thread(poller);
+            this.pollerThread.start();
+        }
+
+        /**
+         * Stops the poller process and thread if currently running.
+         *
+         * @throws InterruptedException Stopping of previous poller instance was interrupted
+         */
+        private void stopPoller() throws InterruptedException {
+            // Stop previous poller process if available
+            if (this.pollerProcess != null) {
+                this.pollerProcess.destroy();
+                this.pollerProcess = null;
+            }
+
+            // Stop previous poller thread if available
+            if (this.pollerThread != null) {
+                this.pollerThread.interrupt();
+                this.pollerThread.join();
+                this.pollerThread = null;
+            }
+
+            // Kill previous poller instance
+            this.poller = null;
+        }
+    }
+
+    /**
+     * Poller class which implements {@link Runnable} and is supposed to be launched in a separate thread by {@link PollerManager}.
+     * This poller will permanently monitor the standard output of the mode2 and tries to interpret them as a IR signal.
+     * In case of a successful match, the handler specified by {@link #onKeyPressedHandler} will be dispatched.
+     */
+    private final class Poller implements Runnable {
+        /**
+         * Timeout in milliseconds before signal processing gets aborted
+         */
+        private final static long SIGNAL_TIMEOUT_MILLISECONDS = 250;
+        /**
+         * Maximum time for raising or falling edge of a pulse in microseconds before being discarded
+         */
+        private final static long PULSE_TIMEOUT_MICROSECONDS = 2400;
+        /**
+         * Time in microseconds for a time slice of a pulse, can be used to measure a pulse length
+         */
+        private final static long PULSE_TIME_SLICE_MICROSECONDS = 60;
+        /**
+         * Threshold of time slice count before considering the current bit as set
+         */
+        private final static long PULSE_SET_BIT_THRESHOLD = 12;
+
+        /**
+         * Buffered reader for processing stdout of mode2 line-by-line
+         */
+        private final BufferedReader stdout;
+        /**
+         * Regex pattern for interpreting a mode2 "pulse" via stdout (pulse = raising edge)
+         */
+        private final Pattern pulsePattern = Pattern.compile("^pulse (\\d+)$");
+        /**
+         * Regex pattern for interpreting a mode2 "space" via stdout (space = falling edge)
+         */
+        private final Pattern spacePattern = Pattern.compile("^space (\\d+)$");
+
+        /**
+         * Constructs a new poller for the given stdout input stream of a mode2 process.
+         *
+         * @param stdout Input stream of mode2 stdout
+         */
+        public Poller(InputStream stdout) {
+            this.stdout = new BufferedReader(new InputStreamReader(stdout));
+        }
+
+        @Override
+        public void run() {
+            while (!Thread.interrupted()) {
+                try {
+                    // Sleep shortly before retrying if no output is available
+                    if (!stdout.ready()) {
+                        sleep(1);
+                        continue;
+                    }
+
+                    // We have some output ready, attempt to parse IR signal
+                    processSignal();
+                } catch (IOException e) {
+                    logger.warn("Received exception during IR signal processing", e);
+                }
+            }
+        }
+
+        /**
+         * Processes a single IR signal consisting out of 32 different pulses, resulting in a 4 byte value.
+         * These 4 bytes are used to calculate two checksums and the third value is equal to the payload / keycode.
+         *
+         * @throws IOException Reading from stdout stream has failed
+         */
+        private void processSignal() throws IOException {
+            // Initialize state variables for this measurement
+            long deadline = System.currentTimeMillis() + SIGNAL_TIMEOUT_MILLISECONDS;
+            final var pulses = new ArrayList<Pulse>();
+            long lastRaisingEdge = -1;
+
+            // Output debug message informing about measurement start
+            logger.debug("Starting IR signal measurement with timeout of {}ms", SIGNAL_TIMEOUT_MILLISECONDS);
+
+            // Wait for 32 valid pulses or timeout to occur
+            while (!Thread.interrupted() && System.currentTimeMillis() < deadline && pulses.size() < 32) {
+                // If there is no output available, sleep shortly before retrying
+                if (!stdout.ready()) {
+                    sleep(1);
+                    continue;
+                }
+
+                // Read output line and initialize matchers
+                final var line = stdout.readLine();
+                final var pulseMatcher = pulsePattern.matcher(line);
+                final var spaceMatcher = spacePattern.matcher(line);
+                logger.trace("Received output from mode2: {}", line);
+
+                // If we have a pulse, store the time in `lastRaisingEdge` and continue loop
+                if (pulseMatcher.matches()) {
+                    lastRaisingEdge = Long.parseLong(pulseMatcher.group(1));
+                    continue;
+                }
+
+                // Ignore and continue loop if we do not match a space or have no known raising edge time
+                if (!spaceMatcher.matches() || lastRaisingEdge == -1) {
+                    continue;
+                }
+
+                // Parse time needed for falling edge, instantiate a new pulse and reset last raising edge
+                final long lastFallingEdge = Long.parseLong(spaceMatcher.group(1));
+                final var pulse = new Pulse(lastRaisingEdge, lastFallingEdge);
+                lastRaisingEdge = -1;
+
+                // Skip this pulse if either edge has taken too long
+                if (pulse.getMaxEdgeTime() >= PULSE_TIMEOUT_MICROSECONDS) {
+                    logger.trace("Skipping pulse which took too long: {}", pulse);
+                    continue;
+                }
+
+                // Otherwise collect this pulse for later processing
+                logger.trace("Added pulse for later processing: {}", pulse);
+                pulses.add(pulse);
+            }
+
+            // Silently abort if we have not received enough pulses
+            if (pulses.size() != 32) {
+                logger.debug("IR signal measurement timed out with {} detected pulses", pulses.size());
+                return;
+            }
+
+            // Construct IR payload by analyzing pulses
+            final var payload = new byte[4];
+            int shiftOffset = 0;
+            int payloadIndex = 0;
+
+            for (final var pulse : pulses) {
+                // Count number of full time slices which occurred during falling edge
+                final long count = pulse.getFallingEdge() / PULSE_TIME_SLICE_MICROSECONDS;
+
+                // Check if we crossed the threshold to consider the current bit as set
+                if (count >= PULSE_SET_BIT_THRESHOLD) {
+                    payload[payloadIndex] |= 1 << shiftOffset;
+                    logger.trace("Setting bit {} for payload[{}] for pulse length {}", shiftOffset, payloadIndex, count);
+                } else {
+                    logger.trace("Clearing bit {} for payload[{}] for pulse length {}", shiftOffset, payload, count);
+                }
+
+                // Once we have reached bit 7 we will wrap around to the next bit
+                // Otherwise we continue shifting, allowing us to set each bit one-by-one
+                if (shiftOffset == 7) {
+                    shiftOffset = 0;
+                    payloadIndex++;
+                } else {
+                    shiftOffset++;
+                }
+            }
+
+            // Calculate checksums for IR signal
+            final byte checksumA = (byte) (payload[0] + payload[1]);
+            final byte checksumB = (byte) (payload[2] + payload[3]);
+            logger.debug("Calculated checksums {} and {} for IR payload {}",
+                ByteHelpers.toString(checksumA), ByteHelpers.toString(checksumB), ByteHelpers.toString(payload));
+
+            // Silently abort if checksum does not match expected values
+            if (checksumA != (byte) 0xFF || checksumB != (byte) 0xFF) {
+                logger.debug("Skipping IR signal due to checksum mismatch");
+                return;
+            }
+
+            // Attempt to map keycode to well-known key
+            final byte keyCode = payload[2];
+            final var key = Key.fromCode(keyCode);
+            if (key == null) {
+                logger.info("Ignoring unknown IR key code {}", ByteHelpers.toString(keyCode));
+                return;
+            }
+
+            // Dispatch onKeyPressed handler with IR key if available
+            final var handler = onKeyPressedHandler.get();
+            if (handler != null) {
+                logger.debug("Dispatching onKeyPressed event for IR key {}", key);
+                handler.handle(key);
+            } else {
+                logger.debug("Skipping dispatch of IR key {} due to missing handler", key);
+            }
+        }
+
+        /**
+         * Helper class for storing a pulse which consist of a raising and falling edge
+         */
+        private final class Pulse {
+            /**
+             * Time it took in microseconds to get the raising edge for this pulse
+             */
+            private final long raisingEdge;
+            /**
+             * Time it took in microseconds to get the falling edge for this pulse
+             */
+            private final long fallingEdge;
+
+            /**
+             * Constructs a new pulse for the given times.
+             *
+             * @param raisingEdge Time of raising edge in microseconds
+             * @param fallingEdge Time of falling edge in microseconds
+             */
+            public Pulse(long raisingEdge, long fallingEdge) {
+                this.raisingEdge = raisingEdge;
+                this.fallingEdge = fallingEdge;
+            }
+
+            /**
+             * Returns either the raising or falling edge time in microseconds, based on which value is higher.
+             *
+             * @return Time in microseconds
+             */
+            public long getMaxEdgeTime() {
+                return Math.max(raisingEdge, fallingEdge);
+            }
+
+            /**
+             * Returns the time for the raising edge in microseconds.
+             *
+             * @return Time in microseconds
+             */
+            public long getRaisingEdge() {
+                return raisingEdge;
+            }
+
+            /**
+             * Returns the time for the falling edge in microseconds.
+             *
+             * @return Time in microseconds
+             */
+            public long getFallingEdge() {
+                return fallingEdge;
+            }
+
+            @Override
+            public String toString() {
+                return "Pulse{" +
+                    "raisingEdge=" + raisingEdge +
+                    ", fallingEdge=" + fallingEdge +
+                    '}';
+            }
+        }
+    }
+
+    /**
+     * Enumeration which represents all known keycodes for the bundled CrowPi IR remote
+     */
+    public enum Key {
+        CH_MINUS("CH-", 0x45),
+        CH("CH", 0x46),
+        CH_PLUS("CH+", 0x47),
+        PREV("PREV", 0x44),
+        NEXT("NEXT", 0x40),
+        PLAY_PAUSE("PLAY/PAUSE", 0x43),
+        VOL_MINUS("VOL-", 0x07),
+        VOL_PLUS("VOL+", 0x15),
+        EQ("EQ", 0x09),
+        ZERO("0", 0x16),
+        HUNDRED_PLUS("100+", 0x19),
+        TWO_HUNDRED_PLUS("200+", 0x0D),
+        ONE("1", 0x0C),
+        TWO("2", 0x18),
+        THREE("3", 0x5E),
+        FOUR("4", 0x08),
+        FIVE("5", 0x1C),
+        SIX("6", 0x5A),
+        SEVEN("7", 0x42),
+        EIGHT("8", 0x52),
+        NINE("9", 0x4A);
+
+        private final byte code;
+        private final String description;
+
+        Key(String description, int code) {
+            this(description, (byte) code);
+        }
+
+        Key(String description, byte code) {
+            this.code = code;
+            this.description = description;
+        }
+
+        /**
+         * Returns the first key which matches the passed key code or null if no match is found.
+         *
+         * @param code Keycode as byte
+         * @return Matched key if found or null if not found
+         */
+        public static Key fromCode(byte code) {
+            for (final var key : Key.values()) {
+                if (key.getCode() == code) {
+                    return key;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Returns the keycode of the key.
+         *
+         * @return Keycode as byte
+         */
+        public byte getCode() {
+            return code;
+        }
+
+        /**
+         * Returns the description of the key.
+         *
+         * @return Human-readable key description matching the labels on the remote
+         */
+        public String getDescription() {
+            return description;
+        }
+
+        @Override
+        public String toString() {
+            return getDescription();
+        }
+    }
+}

--- a/src/test/java/com/pi4j/crowpi/components/IrReceiverComponentTest.java
+++ b/src/test/java/com/pi4j/crowpi/components/IrReceiverComponentTest.java
@@ -1,0 +1,417 @@
+package com.pi4j.crowpi.components;
+
+import com.pi4j.crowpi.ComponentTest;
+import com.pi4j.crowpi.components.IrReceiverComponent.Key;
+import com.pi4j.crowpi.components.IrReceiverComponent.PollerProcess;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IrReceiverComponentTest extends ComponentTest {
+    protected IrReceiverComponent irReceiver;
+
+    @BeforeEach
+    void setUp() {
+        this.irReceiver = new IrReceiverComponent();
+        this.irReceiver.pollerProcessFactory = MockPollerProcess::new;
+    }
+
+    @AfterEach
+    void tearDown() {
+        this.irReceiver.onKeyPressed(null);
+    }
+
+    @Test
+    void testAutoStartPoller() {
+        // when
+        irReceiver.onKeyPressed(key -> {
+        });
+
+        // then
+        assertNotNull(irReceiver.getPollerManagerThread());
+    }
+
+    @Test
+    void testAutoStopPoller() {
+        // given
+        irReceiver.onKeyPressed(key -> {
+        });
+        final var thread = irReceiver.getPollerManagerThread();
+
+        // when
+        irReceiver.onKeyPressed(null);
+
+        // then
+        assertFalse(thread.isAlive());
+        assertNull(irReceiver.getPollerManagerThread());
+    }
+
+    @Test
+    void testAutoRestartPoller() throws InterruptedException {
+        // given
+        final var oldPollerLatch = new CountDownLatch(1);
+        irReceiver.pollerProcessFactory = () -> new MockPollerProcess(oldPollerLatch);
+        irReceiver.onKeyPressed(key -> {
+        });
+
+        final var pollerManager = irReceiver.getPollerManager();
+        assertTrue(oldPollerLatch.await(250, TimeUnit.MILLISECONDS));
+        final var oldPollerProcess = pollerManager != null ? pollerManager.getPollerProcess() : null;
+
+        final var newPollerLatch = new CountDownLatch(1);
+        irReceiver.pollerProcessFactory = () -> new MockPollerProcess(newPollerLatch);
+
+        // when
+        if (oldPollerProcess != null) {
+            oldPollerProcess.destroy();
+        }
+
+        // then
+        assertNotNull(pollerManager);
+        assertNotNull(oldPollerProcess);
+        assertTrue(newPollerLatch.await(250, TimeUnit.MILLISECONDS));
+
+        final var newPollerProcess = pollerManager.getPollerProcess();
+        assertNotEquals(oldPollerProcess, newPollerProcess);
+        assertFalse(oldPollerProcess.isAlive());
+        assertTrue(newPollerProcess.isAlive());
+    }
+
+    @Test
+    void testPlayPauseSignal() throws InterruptedException {
+        // given
+        irReceiver.pollerProcessFactory = () -> new MockPollerProcess(IR_SIGNAL_PLAY_PAUSE);
+        final var latch = new CountDownLatch(1);
+        final var detectedKey = new AtomicReference<Key>();
+
+        // when
+        irReceiver.onKeyPressed(key -> {
+            detectedKey.set(key);
+            latch.countDown();
+        });
+
+        // then
+        assertTrue(latch.await(250, TimeUnit.MILLISECONDS));
+        assertEquals(Key.PLAY_PAUSE, detectedKey.get());
+    }
+
+    @Test
+    void testInvalidSignal() throws InterruptedException, IOException {
+        // given
+        final var pollerProcess = new MockPollerProcess(IR_SIGNAL_INVALID);
+        irReceiver.pollerProcessFactory = () -> pollerProcess;
+        final var latch = new CountDownLatch(1);
+
+        // when
+        irReceiver.onKeyPressed(key -> latch.countDown());
+
+        // then
+        assertFalse(latch.await(250, TimeUnit.MILLISECONDS));
+        assertEquals(0, pollerProcess.getInputStream().available());
+    }
+
+    @Test
+    void testIncompleteSignal() throws InterruptedException, IOException {
+        // given
+        final var pollerProcess = new MockPollerProcess(IR_SIGNAL_INCOMPLETE);
+        irReceiver.pollerProcessFactory = () -> pollerProcess;
+        final var latch = new CountDownLatch(1);
+
+        // when
+        irReceiver.onKeyPressed(key -> latch.countDown());
+
+        // then
+        assertFalse(latch.await(250, TimeUnit.MILLISECONDS));
+        assertEquals(0, pollerProcess.getInputStream().available());
+    }
+
+    private static final class MockPollerProcess implements PollerProcess {
+        private final ByteArrayInputStream inputStream;
+        private final CountDownLatch isReadyLatch;
+        private boolean isAlive = true;
+
+        public MockPollerProcess() {
+            this("", null);
+        }
+
+        public MockPollerProcess(String stdout) {
+            this(stdout, null);
+        }
+
+        public MockPollerProcess(CountDownLatch isReadyLatch) {
+            this("", isReadyLatch);
+        }
+
+        public MockPollerProcess(String stdout, CountDownLatch isReadyLatch) {
+            this.inputStream = new ByteArrayInputStream(stdout.getBytes());
+            this.isReadyLatch = isReadyLatch;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            if (isReadyLatch != null) {
+                isReadyLatch.countDown();
+            }
+            return inputStream;
+        }
+
+        @Override
+        public boolean isAlive() {
+            return isAlive;
+        }
+
+        @Override
+        public void destroy() {
+            isAlive = false;
+        }
+    }
+
+    /**
+     * Captured output of "mode2 --device /dev/lirc0 --driver default" when pressing the PLAY/PAUSE button on the CrowPi remote.
+     * To be used in tests for simulating a valid IR signal.
+     */
+    private static final String IR_SIGNAL_PLAY_PAUSE = "Using driver default on device /dev/lirc0\n" +
+        "Trying device: /dev/lirc0\n" +
+        "Using device: /dev/lirc0\n" +
+        "space 16777215\n" +
+        "pulse 9064\n" +
+        "space 4443\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 620\n" +
+        "space 534\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 617\n" +
+        "space 537\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 1612\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 619\n" +
+        "space 1616\n" +
+        "pulse 613\n" +
+        "space 1614\n" +
+        "pulse 616\n" +
+        "space 1612\n" +
+        "pulse 618\n" +
+        "space 1611\n" +
+        "pulse 620\n" +
+        "space 1610\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 1612\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 618\n" +
+        "space 536\n" +
+        "pulse 618\n" +
+        "space 536\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 536\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 617\n" +
+        "space 540\n" +
+        "pulse 614\n" +
+        "space 1612\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 1613\n" +
+        "pulse 617\n" +
+        "space 1611\n" +
+        "pulse 619\n" +
+        "space 535\n" +
+        "pulse 617\n" +
+        "space 1612\n" +
+        "pulse 619\n" +
+        "space 39301\n" +
+        "pulse 9074\n" +
+        "space 2186\n" +
+        "pulse 612\n" +
+        "pulse 140477";
+
+    /**
+     * Hand-crafted IR signal with checksum mismatch, based on play/pause button with one space modified
+     */
+    private static final String IR_SIGNAL_INVALID = "Using driver default on device /dev/lirc0\n" +
+        "Trying device: /dev/lirc0\n" +
+        "Using device: /dev/lirc0\n" +
+        "space 16777215\n" +
+        "pulse 9064\n" +
+        "space 4443\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 620\n" +
+        "space 534\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 617\n" +
+        "space 537\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 1612\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 619\n" +
+        "space 1616\n" +
+        "pulse 613\n" +
+        "space 1614\n" +
+        "pulse 616\n" +
+        "space 1612\n" +
+        "pulse 618\n" +
+        "space 1611\n" +
+        "pulse 620\n" +
+        "space 1610\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 1612\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 618\n" +
+        "space 536\n" +
+        "pulse 618\n" +
+        "space 536\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 536\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 617\n" +
+        "space 540\n" +
+        "pulse 614\n" +
+        "space 1612\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 1613\n" +
+        "pulse 617\n" +
+        "space 1611\n" +
+        "pulse 619\n" +
+        "space 535\n" +
+        "pulse 617\n" +
+        "space 540\n" + // this space has been shortened to cause a checksum mismatch
+        "pulse 619\n" +
+        "space 39301\n" +
+        "pulse 9074\n" +
+        "space 2186\n" +
+        "pulse 612\n" +
+        "pulse 140477";
+
+    /**
+     * Hand-crafted IR signal with checksum mismatch, based on play/pause button with one pulse and space missing
+     */
+    private static final String IR_SIGNAL_INCOMPLETE = "Using driver default on device /dev/lirc0\n" +
+        "Trying device: /dev/lirc0\n" +
+        "Using device: /dev/lirc0\n" +
+        "space 16777215\n" +
+        "pulse 9064\n" +
+        "space 4443\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 620\n" +
+        "space 534\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 617\n" +
+        "space 537\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 618\n" +
+        "space 537\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 1612\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 619\n" +
+        "space 1616\n" +
+        "pulse 613\n" +
+        "space 1614\n" +
+        "pulse 616\n" +
+        "space 1612\n" +
+        "pulse 618\n" +
+        "space 1611\n" +
+        "pulse 620\n" +
+        "space 1610\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 1612\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 618\n" +
+        "space 536\n" +
+        "pulse 618\n" +
+        "space 536\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 536\n" +
+        "pulse 619\n" +
+        "space 536\n" +
+        "pulse 617\n" +
+        "space 540\n" +
+        "pulse 614\n" +
+        "space 1612\n" +
+        "pulse 619\n" +
+        "space 1611\n" +
+        "pulse 618\n" +
+        "space 1613\n" +
+        "pulse 617\n" +
+        "space 1611\n" +
+        "pulse 619\n" +
+        "space 535\n" +
+        // here a pulse and space was removed
+        "pulse 619\n" +
+        "space 39301\n" +
+        "pulse 9074\n" +
+        "space 2186\n" +
+        "pulse 612\n" +
+        "pulse 140477";
+}


### PR DESCRIPTION
This PR implements the IR receiver component as tracked in ppmathis/fhnw-crowpi#24. Due to very tight timing constraints and being unable to get this component work with Pi4J itself despite various attempts (event handling with own time measurements, busy-wait loops, loops with sleeps, rounding/approximation, 64-bit kernel, ...) this implementation ended up being fairly special.

It does **not** use Pi4J in any way and in fact does not even get passed a context. It uses `mode2`, a binary utility bundled by LIRC (well-known IR suite, soon™ to be present in our CrowPi image) which will print pulses and spaces registered via IR to stdout, which is then being parsed and converted into an appropriate key with this class.

While this PR is probably somewhat out-of-scope, I thought the IR is a nice and versatile input component, so... here it is!