### PR TITLE
Fix: NPE when directly launching an application

### DIFF
--- a/src/main/java/com/pi4j/crowpi/Launcher.java
+++ b/src/main/java/com/pi4j/crowpi/Launcher.java
@@ -87,6 +87,9 @@ public final class Launcher implements Runnable {
         // Initialize PicoCLI instance
         this.cmdLine = new CommandLine(this);
 
+        // Initialize Pi4J context
+        this.pi4j = CrowPiPlatform.buildNewContext();
+
         // Register application runners as subcommands
         this.applications = applications;
         this.registerApplicationRunners();
@@ -113,12 +116,17 @@ public final class Launcher implements Runnable {
         // Interactively ask the user for a desired target and run it
         // This loop will either run only once or forever, depending on the state of `demoMode`
         do {
-            // Initialize Pi4J context
-            pi4j = CrowPiPlatform.buildNewContext();
+            // Re-initialize Pi4J context if needed
+            if (pi4j == null) {
+                pi4j = CrowPiPlatform.buildNewContext();
+            }
+
             // Run the application
             getTargetInteractively(targets).run();
-            // Clean up
+
+            // Cleanup Pi4J context
             pi4j.shutdown();
+            pi4j = null;
         } while (demoMode);
     }
 

--- a/src/test/java/com/pi4j/crowpi/LauncherTest.java
+++ b/src/test/java/com/pi4j/crowpi/LauncherTest.java
@@ -115,6 +115,7 @@ public class LauncherTest {
     private static final class AppA implements Application {
         @Override
         public void execute(Context pi4j) {
+            assertNotNull(pi4j);
             LauncherTest.EXECUTED_APP_A = true;
         }
     }
@@ -122,6 +123,7 @@ public class LauncherTest {
     private static final class AppB implements Application {
         @Override
         public void execute(Context pi4j) {
+            assertNotNull(pi4j);
             LauncherTest.EXECUTED_APP_B = true;
         }
     }


### PR DESCRIPTION
While working on something else I noticed that it is no longer possible to directly launch an application by specifying it as the first argument, e.g. by running with the property `-Dcrowpi.launcher.args=BuzzerApp`. Reason for that behavior is that directly calling an application will bypass the `run()` method, meaning that the context stored in `pi4j` does not get initialized and therefor causes a NullPointerException.

This PR ensures that a context is always created, but also cleaned up properly after every execution. To avoid this from happening again, I've added a test case covering this scenario as well.