### PR TITLE
Feature: Pseudo-volume control for buzzer component

### DIFF
--- a/src/main/java/com/pi4j/crowpi/applications/BuzzerApp.java
+++ b/src/main/java/com/pi4j/crowpi/applications/BuzzerApp.java
@@ -78,7 +78,7 @@ public class BuzzerApp implements Application {
 
         // Loop through all notes and play them one-by-one
         for (int i = 0; i < NOTES.length; i++) {
-            // Calculate duration of note by dividing one second with tempo
+            // Calculate duration of note by dividing one second with tempo.
             // Tempo represents the actual note type, e.g. tempo=4 -> quarter note -> 0.25s
             final var duration = 1000 / TEMPO[i];
 

--- a/src/main/java/com/pi4j/crowpi/components/BuzzerComponent.java
+++ b/src/main/java/com/pi4j/crowpi/components/BuzzerComponent.java
@@ -35,18 +35,18 @@ public class BuzzerComponent extends Component {
     }
 
     /**
-     * Plays a tone with the given frequency in Hz indefinitely.
+     * Plays a tone with the given frequency in Hz indefinitely with maximum volume.
      * This method is non-blocking and returns immediately.
      * A frequency of zero causes the buzzer to play silence.
      *
      * @param frequency Frequency in Hz
      */
     public void playTone(int frequency) {
-        playTone(frequency, 0);
+        playTone(frequency, 0, 100);
     }
 
     /**
-     * Plays a tone with the given frequency in Hz for a specific duration.
+     * Plays a tone with the given frequency in Hz with maximum volume for a specific duration.
      * This method is blocking and will sleep until the specified duration has passed.
      * A frequency of zero causes the buzzer to play silence.
      * A duration of zero to play the tone indefinitely and return immediately.
@@ -55,10 +55,24 @@ public class BuzzerComponent extends Component {
      * @param duration  Duration in milliseconds
      */
     public void playTone(int frequency, int duration) {
+        playTone(frequency, duration, 100);
+    }
+
+    /**
+     * Plays a tone with the given frequency in Hz and volume in percent for a specific duration.
+     * This method is blocking and will sleep until the specified duration has passed.
+     * A frequency or volume of zero causes the buzzer to play silence.
+     * A duration of zero to play the tone indefinitely and return immediately.
+     *
+     * @param frequency Frequency in Hz
+     * @param duration  Duration in milliseconds
+     * @param volume    Volume expressed as a percentage between 0-100
+     */
+    public void playTone(int frequency, int duration, int volume) {
         if (frequency > 0) {
             // Activate the PWM with a duty cycle of 50% and the given frequency in Hz.
             // This causes the buzzer to be on for half of the time during each cycle, resulting in the desired frequency.
-            pwm.on(50, frequency);
+            pwm.on(calculateDutyCycle(volume), frequency);
 
             // If the duration is larger than zero, the tone should be automatically stopped after the given duration.
             if (duration > 0) {
@@ -86,6 +100,24 @@ public class BuzzerComponent extends Component {
     public void playSilence(int duration) {
         this.playSilence();
         sleep(duration);
+    }
+
+    /**
+     * Calculates the PWM duty cycle for the volume given as a percentage.
+     * By adjusting the duty cycle between 0 and 50, with 0 being the quietest and 50 the loudest, volume control can
+     * be simulated by the acoustic effect this change has on the human ear.
+     *
+     * @param volume Volume as percentage between 0 and 100
+     * @return Duty cycle to be used for PWM control of the buzzer
+     */
+    protected static float calculateDutyCycle(int volume) {
+        // Ensure volume is within legitimate bounds
+        if (volume < 0 || volume > 100) {
+            throw new IllegalArgumentException("Volume must be between 0 and 100");
+        }
+
+        // Divide volume by two, as a duty cycle of 50 is considered as loudest, whereas 0 is fully quiet.
+        return (float) volume / 2;
     }
 
     /**

--- a/src/test/java/com/pi4j/crowpi/components/BuzzerComponentTest.java
+++ b/src/test/java/com/pi4j/crowpi/components/BuzzerComponentTest.java
@@ -4,6 +4,8 @@ import com.pi4j.crowpi.ComponentTest;
 import com.pi4j.io.pwm.Pwm;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,6 +45,17 @@ public class BuzzerComponentTest extends ComponentTest {
     }
 
     @Test
+    public void testPlayToneWithDurationAndVolume() {
+        // when
+        this.buzzer.playTone(1000, 10, 50);
+
+        // then
+        assertTrue(this.buzzerPwm.isOff());
+        assertEquals(1000, buzzerPwm.frequency());
+        assertEquals(25, buzzerPwm.dutyCycle(), DUTY_CYCLE_DELTA);
+    }
+
+    @Test
     public void testPlayToneWithInterrupt() {
         // when
         Thread.currentThread().interrupt();
@@ -75,5 +88,17 @@ public class BuzzerComponentTest extends ComponentTest {
 
         // then
         assertTrue(buzzerPwm.isOff());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "0,0",
+        "25,12.5",
+        "50,25",
+        "75,37.5",
+        "100,50",
+    })
+    public void testCalculateDutyCycle(int volume, float expectedDutyCycle) {
+        assertEquals(expectedDutyCycle, BuzzerComponent.calculateDutyCycle(volume));
     }
 }


### PR DESCRIPTION
This PR is an experiment for a pseudo-volume control for the buzzer component, which by default is kinda loud. Adjusting the duty cycle between 0 and 50 has the effect of sounding more quiet and works quite well on my CrowPi, so this could be a potential addition for the component library.

@DieterHolz Does adjusting the volume work well for your CrowPi as well? In my case, I can clearly hear the difference between volume levels of 20 / 40 / 60 / 80 / 100. To test, just pass an additional argument to `playTone`, e.g. in the predefined `BuzzerApp`.